### PR TITLE
Improvements to handling of the 'package' parameter

### DIFF
--- a/lib/ps/winfwrule.ps1
+++ b/lib/ps/winfwrule.ps1
@@ -50,7 +50,7 @@ function get {
                                 firewall_profile = @($rule.Profile.ToString().ToLower().Split(',').Trim() | Sort-Object)
                                 remote_address = @($addr_filter | Where-Object InstanceID -eq $rule.InstanceID | Select-Object @{n='RemoteAddress'; e={$_.RemoteAddress.ToLower()}} | Select-Object -ExpandProperty RemoteAddress | Sort-Object)
                                 remote_port = @($port_filter | Where-Object InstanceID -eq $rule.InstanceID | Select-Object @{n='RemotePort'; e={$_.RemotePort.ToLower()}} | Select-Object -ExpandProperty RemotePort | Sort-Object)
-                                package = ($app_filter | Where-Object InstanceID -eq $rule.InstanceID | Select-Object @{n='Package'; e={ if ([string]::IsNullOrEmpty($_.Package)) {"NotConfigured"} else {$_.Package}}} | Select-Object -expandproperty Package).ToLower()
+                                package = ($app_filter | Where-Object InstanceID -eq $rule.InstanceID | Select-Object @{n='Package'; e={ if ([string]::IsNullOrEmpty($_.Package)) {"notconfigured"} else {$_.Package}}} | Select-Object -expandproperty Package)
                                 program = ($app_filter | Where-Object InstanceID -eq $rule.InstanceID | Select-Object -ExpandProperty Program).ToLower()
                                 protocol = ($port_filter | Where-Object InstanceID -eq $rule.InstanceID | Select-Object -ExpandProperty Protocol).ToString().ToLower()
                                 service = ($service_filter | Where-Object InstanceID -eq $rule.InstanceID | Select-Object -ExpandProperty Service).ToLower()
@@ -162,7 +162,9 @@ function update {
         $Params.Add("LocalPort", $LocalPort)
     }
 
-    if ($Package) {
+    if ($Package -eq 'notconfigured') {
+        $Params.Add("Package", "")
+    } else {
         $Params.Add("Package", $Package)
     }
 

--- a/lib/puppet/provider/winfwrule/winfwrule.rb
+++ b/lib/puppet/provider/winfwrule/winfwrule.rb
@@ -105,8 +105,8 @@ class Puppet::Provider::Winfwrule::Winfwrule < Puppet::ResourceApi::SimpleProvid
                 if ['name', 'title'].include?(k.to_s)
                     # make name and title uppercase
                     r[:"#{k}"] = r[:"#{k}"].upcase
-                elsif ['description', 'display_name'].include?(k.to_s)
-                    # do nothing to description and display_name, pass through as-is
+                elsif ['description', 'display_name', 'package'].include?(k.to_s)
+                    # do nothing to description, display_name and package, pass through as-is
                 elsif r[:"#{k}"].kind_of?(Array)
                     # convert array elements to lowercase and then sort them
                     r[:"#{k}"] = r[:"#{k}"].map(&:downcase).sort

--- a/lib/puppet/type/winfwrule.rb
+++ b/lib/puppet/type/winfwrule.rb
@@ -71,8 +71,9 @@ Puppet::ResourceApi.register_type(
             desc:       'The local port this firewall rule manages.',
         },
         package: {
-            type:       'Optional[String]',
+            type:       'String',
             desc:       'The package this firewall rule affects.',
+            default:    'notconfigured'
         },
         program: {
             type:       'String',


### PR DESCRIPTION
If the package parameter is not defined in Puppet, the package value should be cleared from the firewall rule. Also, don't canonicalise the package value - pass it through as-is so that SID values resolve to their display names nicely in the windows firewall GUI.